### PR TITLE
bumped python version to 3.9

### DIFF
--- a/example/services/service-one/serverless.yml
+++ b/example/services/service-one/serverless.yml
@@ -7,7 +7,7 @@ plugins:
 provider:
   name: aws
   stage: ${opt:stage, "Test"}
-  runtime: python3.6
+  runtime: python3.9
   role: DefaultRole
   deploymentBucket: aronim-serverless
   environment:

--- a/src/index.js
+++ b/src/index.js
@@ -231,7 +231,7 @@ class ServerlessPluginFastDeploy {
             handler: this.pathHandler,
             memorySize: this.fastDeploy.memorySize,
             name: this.fastDeploy.name,
-            runtime: "python3.6",
+            runtime: "python3.9",
             package: {
                 individually: true,
                 exclude: ["**"],


### PR DESCRIPTION
AWS no longer supports deploying to python3.6 lambda, bumped version to python3.9